### PR TITLE
Add support for running with Robolectric.

### DIFF
--- a/easymock-android-tck/pom.xml
+++ b/easymock-android-tck/pom.xml
@@ -91,7 +91,7 @@
               <arguments>
                 <argument>install</argument>
                 <argument>-r</argument>
-                <argument>${project.build.directory}\${project.build.finalName}.apk</argument>
+                <argument>${project.build.directory}/${project.build.finalName}.apk</argument>
               </arguments>
             </configuration>
           </execution>

--- a/easymock-android-tck/src/org/easymock/android/AndroidTck.java
+++ b/easymock-android-tck/src/org/easymock/android/AndroidTck.java
@@ -40,6 +40,10 @@ public class AndroidTck extends Instrumentation {
       PrintStream printStream = new PrintStream(outputStream);
       System.setOut(printStream);
 
+      System.setProperty(
+        "dexmaker.dexcache",
+        getTargetContext().getCacheDir().getPath());
+
       try {
           testInterface();
           testObject();
@@ -54,13 +58,13 @@ public class AndroidTck extends Instrumentation {
    }
    
    private void testObject() throws IOException {
-      Bundle mock = createMock(Bundle.class);
-      mock.clear();
-      expect(mock.size()).andReturn(10);
+      Activity mock = createMock(Activity.class);
+      mock.onLowMemory();
+      expect(mock.getTaskId()).andReturn(10);
       System.out.println("replay");
       replay(mock);
-      mock.clear();
-      if(mock.size() != 10) {
+      mock.onLowMemory();
+      if(mock.getTaskId() != 10) {
           throw new AssertionError("Should have been 10");
       }
       System.out.println("verify");

--- a/easymock/src/main/java/org/easymock/internal/AndroidSupport.java
+++ b/easymock/src/main/java/org/easymock/internal/AndroidSupport.java
@@ -24,6 +24,12 @@ public final class AndroidSupport {
     static {
         try {
             Class.forName("dalvik.system.PathClassLoader");
+
+            // Also verify that dexmaker is present, if not we might
+            // be running under something like robolectric, which
+            // means we should not use dexmaker
+            Class.forName("com.google.dexmaker.Code");
+
             isAndroid = true;
         } catch (final ClassNotFoundException e) {
             isAndroid = false;


### PR DESCRIPTION
In robolectric, the tests are compiled against an android.jar file
with all the android API present (but they all throw an
UnsupportedOperationException), and Robolectric hacks the ClassLoader
to load a different version of the class when actually loaded. This
makes the existing test pass even though we're running in a JVM.

To fix this, the strategy I took was to not attempt to use dexmaker if
it's not available, ideally the robolectric tests shouldn't be
compiled against dexmaker anyway.

I also fixed the instrumentation tests, so that I could test these
changes. Bundle was a final class, and the test was failing saying it
couldn't mock it. I also had to add the "dexmaker.dexcache" system
property for the test to run, it's unclear to me under what situations
this is actually needed, but it was needed for me.

We have robolectric, robolectric2 and instrumentation tests, and all
seem to pass with this change.
