### PR TITLE
Use CGLIB distro which does not depend on ASM 4

### DIFF
--- a/easymock/pom.xml
+++ b/easymock/pom.xml
@@ -34,7 +34,7 @@
     <!-- Used for class mocking -->
     <dependency>
       <groupId>cglib</groupId>
-      <artifactId>cglib</artifactId>
+      <artifactId>cglib-nodep</artifactId>
       <version>3.1</version>
     </dependency>
     <!-- Use version 5 to be compliant with Java 8 -->


### PR DESCRIPTION
Since EasyMock is already depending on ASM 5, switch the to the distribution of CGLIB which does not include an ASM dependency.

I have a JUnit aggregation project that gets included with a scope of test that includes EasyMock etc. so that all the testing utilities can be pulled in with one dependency. Anyway, for some reason, Maven was giving CGLIB 5 a scope of compile in the project including the testing utilities aggregate project no matter what I did unless I made EasyMock exclude CGLIB and I added my own dependency to the cglib-nodep distribution.

I have not tested this to see if this still happens when EasyMock is not being included transitively, but it could not hurt to leave out the dependency on ASM 4.