### PR TITLE
JavaDoc Descr. Inprovement and Spelling Mistake

### DIFF
--- a/easymock/src/main/java/org/easymock/EasyMockSupport.java
+++ b/easymock/src/main/java/org/easymock/EasyMockSupport.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Helper class to be used to keep tracks of mocks easily. See EasyMock
+ * Helper class to keep track of mocks easily. See EasyMock
  * documentation and SupportTest sample.
  * <p>
  * Example of usage:


### PR DESCRIPTION
Minor description improvement and fix spelling mistake.

Change from: Helper class to be used to keep tracks of mocks easily
Change to: Helper class to keep track of mocks easily