### PR TITLE
Add Transform capability to Capture before saving.

### DIFF
--- a/easymock/src/main/java/org/easymock/Capture.java
+++ b/easymock/src/main/java/org/easymock/Capture.java
@@ -34,6 +34,8 @@ public class Capture<T> implements Serializable {
 
     private CaptureType type;
 
+    private Transform<T> transform = identity();
+
     private final List<T> values = new ArrayList<T>(2);
 
     /**
@@ -58,6 +60,11 @@ public class Capture<T> implements Serializable {
         this.type = type;
     }
 
+    private Capture(CaptureType type, Transform<T> transform) {
+        this.type = type;
+        this.transform = transform;
+    }
+
     /**
      * Create a new capture instance that will keep only the last captured value
      *
@@ -79,6 +86,32 @@ public class Capture<T> implements Serializable {
     @SuppressWarnings("deprecation")
     public static <T> Capture<T> newInstance(CaptureType type) {
         return new Capture<T>(type);
+    }
+
+    /**
+     * Create a new capture instance with a specific {@link org.easymock.CaptureType}
+     * and a specific {@link org.easymock.Capture.Transform} function to change the values
+     * into a different value.
+     *
+     * @param type capture type wanted
+     * @param transform the transform function
+     * @param <T> type of the class to be captured
+     * @return the new capture object
+     */
+    public static <T> Capture<T> newInstance(CaptureType type, Transform<T> transform) {
+        return new Capture<T>(type, transform);
+    }
+
+    /**
+     * Create a new capture instance with a specific {@link org.easymock.Capture.Transform}
+     * function to change the values into a different value.
+     *
+     * @param transform the transform function
+     * @param <T> type of the class to be captured
+     * @return the new capture object
+     */
+    public static <T> Capture<T> newInstance(Transform<T> transform) {
+        return new Capture<T>(CaptureType.LAST, transform);
     }
 
     /**
@@ -130,6 +163,7 @@ public class Capture<T> implements Serializable {
      *            Value captured
      */
     public void setValue(T value) {
+        value = transform == null ? value : transform.apply(value);
         switch (type) {
         case NONE:
             break;
@@ -163,5 +197,19 @@ public class Capture<T> implements Serializable {
             return String.valueOf(values.get(0));
         }
         return values.toString();
+    }
+
+    public static <T> Transform<T> identity() {
+        return new Identity<T>();
+    }
+
+    public interface Transform<T> {
+        T apply(T t);
+    }
+
+    static class Identity<T> implements Transform<T> {
+        public T apply(T t) {
+            return t;
+        }
     }
 }

--- a/easymock/src/main/java/org/easymock/EasyMock.java
+++ b/easymock/src/main/java/org/easymock/EasyMock.java
@@ -1830,6 +1830,32 @@ public class EasyMock {
     }
 
     /**
+     * Create a new capture instance with a specific {@link org.easymock.CaptureType}
+     * and a specific {@link org.easymock.Capture.Transform} function to change the values
+     * into a different value.
+     *
+     * @param type capture type wanted
+     * @param transform the transform function
+     * @param <T> type of the class to be captured
+     * @return the new capture object
+     */
+    public static <T> Capture<T> newCapture(CaptureType type, Capture.Transform<T> transform) {
+        return Capture.newInstance(type, transform);
+    }
+
+    /**
+     * Create a new capture instance with a specific {@link org.easymock.Capture.Transform}
+     * function to change the values into a different value.
+     *
+     * @param transform the transform function
+     * @param <T> type of the class to be captured
+     * @return the new capture object
+     */
+    public static <T> Capture<T> newCapture(Capture.Transform<T> transform) {
+        return Capture.newInstance(transform);
+    }
+
+    /**
      * Expect any object but captures it for later use.
      * 
      * @param <T>

--- a/easymock/src/test/java/org/easymock/tests2/CaptureTest.java
+++ b/easymock/src/test/java/org/easymock/tests2/CaptureTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.easymock.Capture;
+import org.easymock.Capture.Transform;
 import org.easymock.CaptureType;
 import org.easymock.tests.IMethods;
 import org.junit.After;
@@ -378,5 +379,51 @@ public class CaptureTest {
         mock.oneArg(Long.valueOf(1));
 
         assertEquals(Long.valueOf(0), capture.getValue());
+    }
+
+    private <T> Capture<Integer> testCaptureTypeAndTransform(CaptureType type) {
+        IMethods mock = createMock(IMethods.class);
+        Capture<Integer> captured = Capture.newInstance(type, new Transform<Integer>() {
+            public Integer apply(Integer t) {
+                return t.intValue() * 100;
+            }
+        });
+
+        expect(mock.oneArg(captureInt(captured))).andReturn("1");
+        expect(mock.oneArg(anyInt())).andReturn("1");
+        expect(mock.oneArg(captureInt(captured))).andReturn("2").times(2);
+        mock.twoArgumentMethod(captureInt(captured), eq(6));
+        mock.twoArgumentMethod(captureInt(captured), captureInt(captured));
+
+        replay(mock);
+
+        mock.oneArg(1);
+        mock.oneArg(2);
+        mock.oneArg(3);
+        mock.oneArg(4);
+        mock.twoArgumentMethod(5, 6);
+        mock.twoArgumentMethod(7, 8);
+
+        verify(mock);
+
+        return captured;
+    }
+
+    @Test
+    public void testTransformFirst() {
+        Capture<Integer> captured = testCaptureTypeAndTransform(CaptureType.FIRST);
+        assertEquals(100, (int) captured.getValue());
+    }
+
+    @Test
+    public void testTransformLast() {
+        Capture<Integer> captured = testCaptureTypeAndTransform(CaptureType.LAST);
+        assertEquals(800, (int) captured.getValue());
+    }
+
+    @Test
+    public void testTransformAll() {
+        Capture<Integer> captured = testCaptureTypeAndTransform(CaptureType.ALL);
+        assertEquals(Arrays.asList(100, 300, 400, 500, 700, 800), captured.getValues());
     }
 }


### PR DESCRIPTION
In some cases, we need to transform the value being captured before it is saved.  

This is especially important when a calling object, for optimization reasons, may be reusing the passed argument, and therefore, we want to capture a copy of the given argument.

This pull request adds the ability to optionally transform the captured object.

Ideally, we would be able to transform the object into a different type, but that would require an additional argument on `Capture<T>`, so I've left this PR simple for now, and the transform must return the same type.

Further, in Java8, the `Transform<T>` could be replaced by `java.util.function.Function<T,R>`.  Regardless, users can still use lambdas to define the Transform here, making the api fairly easy to use.

for example:

```
    Capture<byte[]> captured = newCapture(CaptureType.ALL, (byte[] value) -> Arrays.copyOf(value, value.length));
```

I used to do this with anonymous inner classes, but that was ugly.  And now that the constructors are deprecated, this change seems even more like a better approach.  

```
    Capture<byte[]> captured = new Capture<byte[]>(CaptureType.ALL)
    {
      @Override
      public void setValue(byte[] value)
      {
        // Avoids issue with the reuse of the same byte[] when writing
        super.setValue(Arrays.copyOf(value, value.length));
      }
    };
```
