### PR TITLE
Allow Groovy tests to run without explicit casting in eq()

### DIFF
--- a/core/src/main/java/org/easymock/EasyMock.java
+++ b/core/src/main/java/org/easymock/EasyMock.java
@@ -1384,7 +1384,7 @@ public class EasyMock {
      *            the given value.
      * @return {@code 0}.
      */
-    public static boolean eq(Boolean value) {
+    public static Boolean eq(Boolean value) {
         reportMatcher(new Equals(value));
         return false;
     }
@@ -1420,7 +1420,7 @@ public class EasyMock {
      *            the given value.
      * @return {@code 0}.
      */
-    public static char eq(Character value) {
+    public static Character eq(Character value) {
         reportMatcher(new Equals(value));
         return 0;
     }
@@ -1444,9 +1444,9 @@ public class EasyMock {
      *            the given value.
      * @return {@code 0}.
      */
-    public static double eq(Double value) {
+    public static Double eq(Double value) {
         reportMatcher(new Equals(value));
-        return 0;
+        return 0d;
     }
 
     /**
@@ -1468,9 +1468,9 @@ public class EasyMock {
      *            the given value.
      * @return {@code 0}.
      */
-    public static float eq(Float value) {
+    public static Float eq(Float value) {
         reportMatcher(new Equals(value));
-        return 0;
+        return 0f;
     }
 
     /**
@@ -1492,7 +1492,7 @@ public class EasyMock {
      *            the given value.
      * @return {@code 0}.
      */
-    public static int eq(Integer value) {
+    public static Integer eq(Integer value) {
         reportMatcher(new Equals(value));
         return 0;
     }
@@ -1516,9 +1516,9 @@ public class EasyMock {
      *            the given value.
      * @return {@code 0}.
      */
-    public static long eq(Long value) {
+    public static Long eq(Long value) {
         reportMatcher(new Equals(value));
-        return 0;
+        return 0L;
     }
 
     /**
@@ -1540,7 +1540,7 @@ public class EasyMock {
      *            the given value.
      * @return {@code 0}.
      */
-    public static short eq(Short value) {
+    public static Short eq(Short value) {
         reportMatcher(new Equals(value));
         return 0;
     }

--- a/core/src/main/java/org/easymock/EasyMock.java
+++ b/core/src/main/java/org/easymock/EasyMock.java
@@ -1378,6 +1378,18 @@ public class EasyMock {
     }
 
     /**
+     * Expects a Boolean that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static boolean eq(Boolean value) {
+        reportMatcher(new Equals(value));
+        return false;
+    }
+
+    /**
      * Expects a byte that is equal to the given value.
      *
      * @param value
@@ -1402,6 +1414,18 @@ public class EasyMock {
     }
 
     /**
+     * Expects a Character that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static char eq(Character value) {
+        reportMatcher(new Equals(value));
+        return 0;
+    }
+
+    /**
      * Expects a double that is equal to the given value.
      *
      * @param value
@@ -1409,6 +1433,18 @@ public class EasyMock {
      * @return {@code 0}.
      */
     public static double eq(double value) {
+        reportMatcher(new Equals(value));
+        return 0;
+    }
+
+    /**
+     * Expects a Double that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static double eq(Double value) {
         reportMatcher(new Equals(value));
         return 0;
     }
@@ -1426,6 +1462,18 @@ public class EasyMock {
     }
 
     /**
+     * Expects a Float that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static float eq(Float value) {
+        reportMatcher(new Equals(value));
+        return 0;
+    }
+
+    /**
      * Expects an int that is equal to the given value.
      *
      * @param value
@@ -1433,6 +1481,18 @@ public class EasyMock {
      * @return {@code 0}.
      */
     public static int eq(int value) {
+        reportMatcher(new Equals(value));
+        return 0;
+    }
+
+    /**
+     * Expects an Integer that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static int eq(Integer value) {
         reportMatcher(new Equals(value));
         return 0;
     }
@@ -1450,6 +1510,18 @@ public class EasyMock {
     }
 
     /**
+     * Expects a Long that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static long eq(Long value) {
+        reportMatcher(new Equals(value));
+        return 0;
+    }
+
+    /**
      * Expects a short that is equal to the given value.
      *
      * @param value
@@ -1459,6 +1531,30 @@ public class EasyMock {
     public static short eq(short value) {
         reportMatcher(new Equals(value));
         return 0;
+    }
+
+    /**
+     * Expects a Short that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static short eq(Short value) {
+        reportMatcher(new Equals(value));
+        return 0;
+    }
+
+    /**
+     * Expects a BigDecimal that is equal to the given value.
+     *
+     * @param value
+     *            the given value.
+     * @return {@code 0}.
+     */
+    public static java.math.BigDecimal eq(java.math.BigDecimal value) {
+        reportMatcher(new Equals(value));
+        return new java.math.BigDecimal(0);
     }
 
     /**


### PR DESCRIPTION
Considering #180, I've added some new handlers for wrapper types separately because otherwise the `Object` handler is used and it returns `null` which doesn't play well with autoboxing.

BigDecimal handler is needed because:
```
print 1.2.getClass().toString()
Output: java.math.BigDecimal
```

The following test now works with groovy
```groovy
class DemoTest extends GroovyTestCase {
    void testTest() {
        Demo mock = mock(Demo)
        
        expect(mock.testBool(eq(true)))
                .andReturn("test")
        expect(mock.testChar(eq((char)'a')))
                .andReturn("test")
        expect(mock.testDouble(eq(1.2)))
                .andReturn("test")
        expect(mock.testFloat(eq(1.1f)))
                .andReturn("test")
        expect(mock.testLong(eq(22l)))
                .andReturn("test")
        expect(mock.testShort(eq((short)2)))
                .andReturn("test")
        expect(mock.testInt(2))
                .andReturn("test")

        replay(mock)

    }
}
```

```java
public class Demo {


    public String testLong(long a) {
        return "a";
    }

    public String testDouble(double a) {
        return "a";
    }

    public String testFloat(float a) {
        return "a";
    }

    public String testChar(char a) {
        return "a";
    }

    public String testShort(short a) {
        return "a";
    }

    public String testBool(boolean a){
        return "a";
    }
    
    public String testInt(int a){
        return "a";
    }

}
```