### PR TITLE
Fix issue 175 by changing ExpectedInvocation.matches

### DIFF
--- a/core/src/main/java/org/easymock/internal/ExpectedInvocation.java
+++ b/core/src/main/java/org/easymock/internal/ExpectedInvocation.java
@@ -82,7 +82,7 @@ public class ExpectedInvocation implements Serializable {
     }
 
     public boolean matches(Invocation actual) {
-        return this.invocation.getMock().equals(actual.getMock())
+        return this.invocation.getMock() == actual.getMock()
                 && this.invocation.getMethod().equals(actual.getMethod()) && matches(actual.getArguments());
     }
 

--- a/core/src/test/java/org/easymock/tests/FinalEqualsTest.java
+++ b/core/src/test/java/org/easymock/tests/FinalEqualsTest.java
@@ -1,0 +1,34 @@
+package org.easymock.tests;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class FinalEqualsTest {
+
+    static class MyInt {
+        private final int i;
+
+        public MyInt(int i) {
+            this.i = i;
+        }
+
+        @Override
+        public final boolean equals(Object obj) {
+            return obj instanceof MyInt && this.get() == ((MyInt) obj).get();
+        }
+
+        public int get() {
+            return i;
+        }
+    }
+
+    @Test
+    public void testGet() {
+        MyInt myInt = createMock(MyInt.class);
+        expect(myInt.get()).andReturn(42);
+        replay(myInt);
+        assertEquals(42, myInt.get());
+    }
+}


### PR DESCRIPTION
I am a little interested in issue 175, which says easymock will crash with following test case:

```
class MyInt {
        private final int i;

        public MyInt(int i) {
            this.i = i;
        }

        @Override
        public final boolean equals(Object obj) {
            return obj instanceof MyInt && this.get() == ((MyInt) obj).get();
        }

        public int get() {
            return i;
        }
    }

    @Test
    public void testGet() {
        MyInt myInt = createMock(MyInt.class);
        expect(myInt.get()).andReturn(42);
        replay(myInt);
        assertEquals(42, myInt.get());
    }
```

This test will cause a StackOverflowError. I found that the reason is because final method cannot be intercepted by easymock. So when `equals` is invoked, it directly calls the original `equals` method. This `equals` will again call `get` method, which is intercepted by easymock. When `get` is invoked the easymock will internally invoke `equals` again, thus form an endless loop.

To solve this problem, I change `ExpectedInvocation.matches` by modifying `this.invocation.getMock().equals(actual.getMock())` to `this.invocation.getMock() == actual.getMock()`. I think it should be safe to use `==` directly because we want the actual object to be exactly the same object which was recorded. And by removing `equals` here we can break the endless loop. So the above test case passes now.
