### PR TITLE
Update various dependencies for Java 9 support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,20 +35,20 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>3.2.4</version>
+      <version>3.2.5</version>
     </dependency>
-    <!-- Use version 5 to be compliant with Java 8 -->
+    <!-- Use version 6 to be compliant with Java 9 -->
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>5.1</version>
+      <version>6.0_BETA</version>
       <scope>runtime</scope>
     </dependency>
     <!-- Used for class mocking -->
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
     <!-- Used for class mocking on Android (cglib replacement) -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
           <executions>
             <execution>
               <id>easymock-bundle</id>
@@ -162,7 +162,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.6.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
@@ -227,7 +227,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.3</version>
+          <version>3.1.0</version>
         </plugin>
         <!--This plugin configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
         <plugin>

--- a/test-integration/pom.xml
+++ b/test-integration/pom.xml
@@ -30,7 +30,7 @@
     <jacoco.skip>true</jacoco.skip>
 
     <!-- Versions -->
-    <powermock.version>1.6.6</powermock.version>
+    <powermock.version>1.7.1</powermock.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Upgrade cglib, asm, objectgenesis and mvn-shade-plugin for Java 9 support.

Also upgrade powermock, mvn-ccompiler-plugin and mvn-assembly-plugin while at it. Note that powermock doesn't support Java 9 yet.

Fixes #193.