### PR TITLE
Update asm, cglib and surefire

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>3.2.5</version>
+      <version>3.2.6</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.ant</groupId>
@@ -43,11 +43,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Use version 6 to be compliant with Java 9 -->
+    <!-- Use version 6.1 to be compliant with Java 10 -->
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>6.0</version>
+      <version>6.1</version>
       <scope>runtime</scope>
     </dependency>
     <!-- Used for class mocking -->

--- a/pom.xml
+++ b/pom.xml
@@ -204,13 +204,13 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.21.0</version>
           <dependencies>
             <dependency>
               <!-- Force junit provider because surefire will choose the testng one if testng is detected -->
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>2.20.1</version>
+              <version>2.21.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
ASM 6.1 adds support for Java 10:

https://mail.ow2.org/wws/arc/asm/2018-03/msg00000.html

Java 10 was released today.