### PR TITLE
Update cglib to 3.2.8 and asm to 6.2.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>3.2.6</version>
+      <version>3.2.8</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.ant</groupId>
@@ -43,11 +43,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Use version 6.2 to be compliant with Java 10 -->
+    <!-- Use version 6.2 to be compliant with Java 11 -->
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>6.2</version>
+      <version>6.2.1</version>
       <scope>runtime</scope>
     </dependency>
     <!-- Used for class mocking -->


### PR DESCRIPTION
cglib 3.2.8 unlocks Java 11 support if the system property `net.sf.cglib.experimental_asm7=true` is set.