### PR TITLE
Try instantiating TestSubject automatically using its constructor without arguments

### DIFF
--- a/core/src/test/java/org/easymock/tests2/EasyMockAutoInstantiationTest.java
+++ b/core/src/test/java/org/easymock/tests2/EasyMockAutoInstantiationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2001-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.easymock.tests2;
+
+import org.easymock.*;
+import org.easymock.tests.IMethods;
+import org.easymock.tests.IVarArgs;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests automated instantiations of {@link org.easymock.TestSubject}
+ *
+ * @author Tatsuya Iwanari
+ */
+@RunWith(EasyMockRunner.class)
+public class EasyMockAutoInstantiationTest extends EasyMockSupport {
+
+    @Mock
+    private IMethods standardMock;
+
+    @Mock(type = MockType.NICE)
+    private IMethods typedMock;
+
+    @Mock(name = "name1")
+    private IMethods namedMock;
+
+    @Mock(name = "name2", type = MockType.NICE)
+    private IMethods namedAndTypedMock;
+
+    @Before
+    public void setup() {
+        assertNotNull(standardMock);
+        assertNotNull(typedMock);
+        assertNotNull(namedMock);
+        assertNotNull(namedAndTypedMock);
+    }
+
+    public static class ToInjectWithoutConstructors {
+        protected IMethods m1;
+
+        protected IMethods m2;
+
+        protected IVarArgs v;
+
+        protected String a;
+
+        protected final IVarArgs f = null;
+
+        protected static IVarArgs s;
+    }
+
+
+    private static class DefaultConstructorInjectionTest {
+        @Mock
+        protected IMethods m;
+
+        @Mock
+        protected IVarArgs v;
+
+        @TestSubject
+        protected ToInjectWithoutConstructors toInject;
+    }
+
+    @Test
+    public void shouldInjectMocksToTestSubjectWithDefaultConstructor() {
+        DefaultConstructorInjectionTest test = new DefaultConstructorInjectionTest();
+        EasyMockSupport.injectMocks(test);
+        assertSame(test.m, test.toInject.m1);
+        assertSame(test.m, test.toInject.m2);
+        assertSame(test.v, test.toInject.v);
+        assertNull(test.toInject.a);
+        assertNull(test.toInject.f);
+        assertNull(ToInjectWithoutConstructors.s);
+    }
+
+    public static class ToInjectWithDefinedDefaultConstructor {
+        protected IMethods m1;
+
+        protected IMethods m2;
+
+        protected IVarArgs v;
+
+        protected String a;
+
+        protected final IVarArgs f = null;
+
+        protected static IVarArgs s;
+
+        ToInjectWithDefinedDefaultConstructor() {}
+    }
+
+    private static class DefinedDefaultConstructorInjectionTest {
+        @Mock
+        protected IMethods m;
+
+        @Mock
+        protected IVarArgs v;
+
+        @TestSubject
+        protected ToInjectWithDefinedDefaultConstructor toInject;
+    }
+
+    @Test
+    public void shouldInjectMocksToTestTargetWithDefinedDefaultConstructor() {
+        DefinedDefaultConstructorInjectionTest test = new DefinedDefaultConstructorInjectionTest();
+        EasyMockSupport.injectMocks(test);
+        assertSame(test.m, test.toInject.m1);
+        assertSame(test.m, test.toInject.m2);
+        assertSame(test.v, test.toInject.v);
+        assertNull(test.toInject.a);
+        assertNull(test.toInject.f);
+        assertNull(ToInjectWithDefinedDefaultConstructor.s);
+    }
+}


### PR DESCRIPTION
### Overview
Hope this will be the first step to #185 [I was playing around with `Injector` to accomplish #185 but it turned out to be more complicated than I initially thought. I'd like your feedback to decide how to work on the next step (or start over from scratch)].

This change tries instantiating a `@TestSubject` automatically using its constructor without any argument when it's not initialized.

For example, the following test case will be able to pass. 
```java
private static class ToInject {
  protected IMethods m;
  protected IVarArgs v;
  ...
  // no declared constructor => default constructor will be created
}

private static class ToInjectMocksTest {
  @Mock
  protected IMethods m;
  @Mock
  protected IVarArgs v;
  @TestSubject
  protected ToInject toInject;
  // protected ToInject toInject = new ToInject();
}

@Test
public void shouldInjectMocksToTestSubjectWithDefaultConstructor() {
  ToInjectMocksTest test = new ToInjectMocksTest();
  EasyMockSupport.injectMocks(test);
  assertSame(test.m, test.toInject.m);
  assertSame(test.v, test.toInject.v);
}
```



### 💻 Implementation details
**What you changed** 
* Added a method to try automatically initializing a uninitialized `@TestSubject` using its default constructor.
* Added a test class.

**Expected behavior**
* This should not break the existing codes/tests. The existing codes should work as before. 
* When a `@TestSubjct` isn't initialized, this change should try to use its default constructor (or manually declared constructor without any arguments) to automatically initialize it. 
   * If the `@TestSubject` doesn't have such a constructor, it should work as before (i.e., it throws an NPE saying "Have you forgotten to instantiate [class name]?"
   * If any reflection error/exception happens, it should throw an NPE saying "Failed to instantiate [class name]?"

**Other consideration**
https://github.com/tiwanari/easymock/pull/1 is a dirty draft for accomplishing #185 at once but I felt it would be better to do this step by step. Although I can try adding the remaining part to this PR if necessary, it's not as easy as it looks.

##### TL;DR: More context why the rest part is difficult 
For this PR, I started with the simplest case (default constructor) but it wasn't that simple either. Please take a look at the following code snippet.

```java
// *** in EasyMockAnnotationsTest ***
private static class ToInject {
  protected IMethods m1;
  protected IMethods m2;
  protected IVarArgs v;
  protected String a;
  protected final IVarArgs f = null;
  protected static IVarArgs s;
}

private static class ToInjectMocksTest {
  @Mock
  protected IMethods m;
  @Mock
  protected IVarArgs v;
  @TestSubject
  protected ToInject toInject = new ToInject();
}
// *** /in EasyMockAnnotationsTest ***

// testSubjectField = toInject
Class<?> type = testSubjectField.getType();
for (Constructor<?> constructor : type.getDeclaredConstructors()) {
    System.out.println(constructor.toString());
}
```
This snippet outputs
```java
private org.easymock.tests2.EasyMockAnnotationsTest$ToInject()
org.easymock.tests2.EasyMockAnnotationsTest$ToInject(org.easymock.tests2.EasyMockAnnotationsTest$1) 
```

The second line, which was unexpected to me, is created by the complier if there's at least one `new ToInject()` for allowing the caller class (`EasyMockAnnotationsTest`) to access the `private` constructor as it should be able to do so (the $1 argument is always null. Please see [this stackoverflow answer](https://stackoverflow.com/a/22296603) for more details).

Therefore, we cannot use `getDeclaredConstructors() == 1` to check if there's only one constructor. Instead we have to try `getDeclaredConstructor()` to see if there's a constructor that doesn't have arguments to find the default constructor. This way works for constructors without arguments.

When a `@TestSubject` has constructors with arguments, we need to do something like [this](https://github.com/tiwanari/easymock/pull/1/files/9313f6f48f450bdb050dbcb2338b64bc52063a98#r337405952) (wip). I first thought using the constructor with the largest number of arguments (e.g., prefer `ToInject(A, B)` over `ToInject(A)`) but the compiler's behavior described above made this solution hard to implement.

There are a few more things to consider. For instance, should we check the accessibility (private/public/protected) of `@TestSubject` properly? I can imagine that the code will need some refactor in this case. Your feedback will be really appreciated. Thank you. 

