### PR TITLE
Allow partial mocking for interfaces with default methods

### DIFF
--- a/core/src/main/java/org/easymock/internal/MockBuilder.java
+++ b/core/src/main/java/org/easymock/internal/MockBuilder.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Default implementation of IMockBuilder.
@@ -41,7 +42,7 @@ import java.util.Set;
  */
 public class MockBuilder<T> implements IMockBuilder<T> {
 
-    private static final ReflectionUtils.Predicate<Method> CAN_BE_MOCKED = method -> {
+    private static final Predicate<Method> CAN_BE_MOCKED = method -> {
         int modifiers = method.getModifiers();
         // Final, static and private methods can't be mocked so just skip
         if((modifiers & (Modifier.STATIC | Modifier.PRIVATE | Modifier.FINAL)) != 0) {

--- a/core/src/main/java/org/easymock/internal/MocksControl.java
+++ b/core/src/main/java/org/easymock/internal/MocksControl.java
@@ -15,12 +15,20 @@
  */
 package org.easymock.internal;
 
-import org.easymock.*;
+import org.easymock.ConstructorArgs;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.easymock.IExpectationSetters;
+import org.easymock.IMocksControl;
+import org.easymock.MockType;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author OFFIS, Tammo Freese
@@ -84,8 +92,10 @@ public class MocksControl implements IMocksControl, IExpectationSetters<Object>,
         if (toMock == null) {
             throw new NullPointerException("Can't mock 'null'");
         }
-        if (toMock.isInterface() && mockedMethods != null) {
-            throw new IllegalArgumentException("Partial mocking doesn't make sense for interface");
+        if (toMock.isInterface() && mockedMethods != null
+            && !hasDefaultMethod(toMock, mockedMethods)) {
+            throw new IllegalArgumentException(
+                "Partial mocking doesn't make sense for interface without default methods");
         }
 
         try {
@@ -109,6 +119,11 @@ public class MocksControl implements IMocksControl, IExpectationSetters<Object>,
         } catch (RuntimeExceptionWrapper e) {
             throw (RuntimeException) e.getRuntimeException().fillInStackTrace();
         }
+    }
+
+    private static boolean hasDefaultMethod(Class<?> toMock, Method[] mockedMethods) {
+        Set<Method> mocked = new HashSet<>(Arrays.asList(mockedMethods));
+        return Arrays.stream(toMock.getMethods()).anyMatch(method -> !mocked.contains(method) && method.isDefault());
     }
 
     public static IProxyFactory getProxyFactory(Object o) {

--- a/core/src/main/java/org/easymock/internal/MocksControl.java
+++ b/core/src/main/java/org/easymock/internal/MocksControl.java
@@ -121,7 +121,7 @@ public class MocksControl implements IMocksControl, IExpectationSetters<Object>,
         }
     }
 
-    private static boolean hasDefaultMethod(Class<?> toMock, Method[] mockedMethods) {
+    private static boolean hasMockedDefaultMethod(Class<?> toMock, Method[] mockedMethods) {
         Set<Method> mocked = new HashSet<>(Arrays.asList(mockedMethods));
         return Arrays.stream(toMock.getMethods()).anyMatch(method -> !mocked.contains(method) && method.isDefault());
     }

--- a/core/src/main/java/org/easymock/internal/MocksControl.java
+++ b/core/src/main/java/org/easymock/internal/MocksControl.java
@@ -135,7 +135,7 @@ public class MocksControl implements IMocksControl, IExpectationSetters<Object>,
     private static IProxyFactory getClassProxyFactory() {
         String classMockingDisabled = EasyMockProperties.getInstance().getProperty(
                 EasyMock.DISABLE_CLASS_MOCKING);
-        if (Boolean.valueOf(classMockingDisabled)) {
+        if (Boolean.parseBoolean(classMockingDisabled)) {
             throw new IllegalArgumentException("Class mocking is currently disabled. Change "
                     + EasyMock.DISABLE_CLASS_MOCKING + " to true do modify this behavior");
         }

--- a/core/src/main/java/org/easymock/internal/ObjectMethodsFilter.java
+++ b/core/src/main/java/org/easymock/internal/ObjectMethodsFilter.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.function.Predicate;
 
 /**
  * @author OFFIS, Tammo Freese
@@ -29,7 +30,7 @@ public class ObjectMethodsFilter implements InvocationHandler, Serializable {
 
     private static final long serialVersionUID = -1726286682930686024L;
 
-    private static final ReflectionUtils.Predicate<Method> NOT_PRIVATE = method -> !Modifier.isPrivate(method.getModifiers());
+    private static final Predicate<Method> NOT_PRIVATE = method -> !Modifier.isPrivate(method.getModifiers());
 
     private transient Method equalsMethod;
 

--- a/core/src/main/java/org/easymock/internal/ReflectionUtils.java
+++ b/core/src/main/java/org/easymock/internal/ReflectionUtils.java
@@ -21,15 +21,12 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * @author Henri Tremblay
  */
 public final class ReflectionUtils {
-
-    public interface Predicate<T> {
-        boolean test(T t);
-    }
 
     public static final Predicate<Method> NOT_PRIVATE = method -> !Modifier.isPrivate(method.getModifiers());
 

--- a/core/src/main/java/org/easymock/internal/ReflectionUtils.java
+++ b/core/src/main/java/org/easymock/internal/ReflectionUtils.java
@@ -21,7 +21,9 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * @author Henri Tremblay
@@ -289,4 +291,18 @@ public final class ReflectionUtils {
         return true;
     }
 
+    /**
+     * Return all default methods of an interface and it's inherited interface.
+     *
+     * @param clazz class for which we want the default method
+     * @return all default methods
+     */
+    public static Set<Method> getDefaultMethods(Class<?> clazz) {
+        if(!clazz.isInterface()) {
+            throw new IllegalArgumentException("Only interfaces can have default methods. Not " + clazz);
+        }
+        return Arrays.stream(clazz.getMethods())
+            .filter(Method::isDefault)
+            .collect(Collectors.toSet());
+    }
 }

--- a/core/src/main/java/org/easymock/internal/ReflectionUtils.java
+++ b/core/src/main/java/org/easymock/internal/ReflectionUtils.java
@@ -46,11 +46,11 @@ public final class ReflectionUtils {
     public static final Method OBJECT_EQUALS = getDeclaredMethod(Object.class, "equals",
         Object.class);
 
-    public static final Method OBJECT_HASHCODE = getDeclaredMethod(Object.class, "hashCode", (Class[]) null);
+    public static final Method OBJECT_HASHCODE = getDeclaredMethod(Object.class, "hashCode", (Class<?>[]) null);
 
-    public static final Method OBJECT_TOSTRING = getDeclaredMethod(Object.class, "toString", (Class[]) null);
+    public static final Method OBJECT_TOSTRING = getDeclaredMethod(Object.class, "toString", (Class<?>[]) null);
 
-    public static final Method OBJECT_FINALIZE = getDeclaredMethod(Object.class, "finalize", (Class[]) null);
+    public static final Method OBJECT_FINALIZE = getDeclaredMethod(Object.class, "finalize", (Class<?>[]) null);
 
     // ///CLOVER:OFF
     private ReflectionUtils() {

--- a/core/src/main/java/org/easymock/internal/ReflectionUtils.java
+++ b/core/src/main/java/org/easymock/internal/ReflectionUtils.java
@@ -149,7 +149,7 @@ public final class ReflectionUtils {
         for(Class<?> i : interfaces) {
             Method[] methods = i.getDeclaredMethods();
             for (Method method : methods) {
-                if(!isDefaultMethod(method)) {
+                if(!method.isDefault()) {
                     continue;
                 }
                 if (name.equals(method.getName())) {
@@ -292,10 +292,4 @@ public final class ReflectionUtils {
         return true;
     }
 
-    public static boolean isDefaultMethod(Method method) {
-        int modifiers = method.getModifiers();
-        // Default methods are public non-abstract instance methods
-        // declared in an interface.
-        return (modifiers & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) == Modifier.PUBLIC;
-    }
 }

--- a/core/src/test/java/org/easymock/tests2/MocksControlDefaultMethodsTest.java
+++ b/core/src/test/java/org/easymock/tests2/MocksControlDefaultMethodsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2001-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.easymock.tests2;
+
+import org.easymock.internal.ReflectionUtils;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+import static org.easymock.EasyMock.createControl;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Henri Tremblay
+ */
+public class MocksControlDefaultMethodsTest {
+
+    @Test
+    public void emptyInterface() {
+        expectPartialMocking("an empty interface", false, Cloneable.class);
+    }
+
+    @Test
+    public void interfaceWithoutDefaultMethods() {
+        expectPartialMocking("an interface without default methods", false, Runnable.class);
+    }
+
+    @Test
+    public void interfaceWithDefaultMethodButNoMockedMethods() {
+        expectPartialMocking("an interface with a default method", true, Function.class);
+    }
+
+    @Test
+    public void interfaceWithDefaultMethodAndMockedMethods() {
+        expectPartialMocking("an interface with a default method and a mocked method", true, Function.class,
+            ReflectionUtils.findMethod(Function.class, "andThen", method -> true));
+    }
+
+    @Test
+    public void interfaceWithInheritedDefaultMethod() {
+        expectPartialMocking("an interface with an inherited default method", true,
+            InterfaceWithInheritedDefaultMethod.class);
+    }
+
+    @Test
+    public void interfaceWithMockedMethodThatIsNotADefaultMethod() {
+        expectPartialMocking("an interface with a mocked method that is not a default method", false,
+            Function.class, ReflectionUtils.findMethod(Function.class, "apply", method -> true));
+    }
+
+    private void expectPartialMocking(String caseName, boolean expected, Class<?> toMock, Method... mockedMethods) {
+        String allowanceText = "should" + (expected ? "" : "n't") + " be allowed";
+        String message = "partial mocking on " + caseName + " " + allowanceText;
+        assertEquals(message, expected, tryMock(toMock, mockedMethods));
+    }
+
+    private boolean tryMock(Class<?> toMock, Method... mockedMethods) {
+        try {
+            createControl().createMock(null, toMock, null, mockedMethods);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private interface InterfaceWithDefaultMethod {
+        default void method() {}
+    }
+
+    private interface InterfaceWithInheritedDefaultMethod extends InterfaceWithDefaultMethod {}
+}

--- a/core/src/test/java/org/easymock/tests2/MocksControlDefaultMethodsTest.java
+++ b/core/src/test/java/org/easymock/tests2/MocksControlDefaultMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2020 the original author or authors.
+ * Copyright 2001-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/easymock/tests2/MocksControlTest.java
+++ b/core/src/test/java/org/easymock/tests2/MocksControlTest.java
@@ -19,7 +19,6 @@ import org.easymock.ConstructorArgs;
 import org.easymock.IMocksControl;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -139,36 +138,6 @@ public class MocksControlTest {
         assertEquals("myMock", a.toString());
     }
 
-    @Test
-    public void testMocksControl_PartialMock_EmptyInterface() {
-        expectPartialMocking("an empty interface", false, EmptyInterface.class);
-    }
-
-    @Test
-    public void testMocksControl_PartialMock_InterfaceWithoutDefaultMethods() {
-        expectPartialMocking("an interface without default methods", false,
-            InterfaceWithoutDefaultMethods.class);
-    }
-
-    @Test
-    public void testMocksControl_PartialMock_InterfaceWithDefaultMethod() {
-        expectPartialMocking("an interface with a default method", true,
-            InterfaceWithDefaultMethod.class);
-    }
-
-    @Test
-    public void testMocksControl_PartialMock_InterfaceWithInheritedDefaultMethod() {
-        expectPartialMocking("an interface with an inherited default method", true,
-            InterfaceWithInheritedDefaultMethod.class);
-    }
-
-    @Test
-    public void testMocksControl_PartialMock_InterfaceWithMockedDefaultMethod() throws Exception {
-        expectPartialMocking("an interface with a mocked default method", false,
-            InterfaceWithDefaultMethod.class,
-            InterfaceWithDefaultMethod.class.getMethod("method"));
-    }
-
     private void testList(IMocksControl ctrl, List<?> list) {
         expect(list.size()).andReturn(3);
         ctrl.replay();
@@ -176,31 +145,4 @@ public class MocksControlTest {
         ctrl.verify();
     }
 
-    private void expectPartialMocking(String caseName, boolean expected,
-        Class<?> toMock, Method... mockedMethods) {
-        String allowanceText = "should" + (expected ? "" : "n't") + " be allowed";
-        String message = "partial mocking on " + caseName + " " + allowanceText;
-        assertEquals(message, expected, tryMock(toMock, mockedMethods));
-    }
-
-    private boolean tryMock(Class<?> toMock, Method... mockedMethods) {
-        try {
-            createControl().createMock(null, toMock, null, mockedMethods);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
-    }
-
-    private interface EmptyInterface {}
-
-    private interface InterfaceWithoutDefaultMethods {
-        void method();
-    }
-
-    private interface InterfaceWithDefaultMethod {
-        default void method() {}
-    }
-
-    private interface InterfaceWithInheritedDefaultMethod extends InterfaceWithDefaultMethod {}
 }

--- a/core/src/test/java/org/easymock/tests2/ReflectionUtilsTest.java
+++ b/core/src/test/java/org/easymock/tests2/ReflectionUtilsTest.java
@@ -20,6 +20,9 @@ import org.junit.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
 
 import static org.easymock.internal.ReflectionUtils.*;
 import static org.junit.Assert.*;
@@ -29,7 +32,7 @@ import static org.junit.Assert.*;
  */
 public class ReflectionUtilsTest {
 
-    private static final Class[] NO_PARAMS = new Class[0];
+    private static final Class<?>[] NO_PARAMS = new Class[0];
 
     public static class B {
         protected void foo(long l) { }
@@ -170,5 +173,27 @@ public class ReflectionUtilsTest {
         Method method = ReflectionUtils.findMethod(A.class, "parentMethod", NOT_PRIVATE, NO_PARAMS);
         assertEquals("parentMethod", method.getName());
         assertEquals(B.class, method.getDeclaringClass());
+    }
+
+    @Test
+    public void testGetDefaultMethods_onClass() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> ReflectionUtils.getDefaultMethods(getClass()));
+        assertEquals("Only interfaces can have default methods. Not " + getClass(), e.getMessage());
+    }
+
+    @Test
+    public void testGetDefaultMethods_noDefaultMethods() {
+        assertTrue(ReflectionUtils.getDefaultMethods(Runnable.class).isEmpty());
+    }
+
+    @Test
+    public void testGetDefaultMethods_withDefaultMethods() {
+        assertEquals(2, ReflectionUtils.getDefaultMethods(Function.class).size());
+    }
+
+    @Test
+    public void testGetDefaultMethods_withDefaultMethodsBaseClass() {
+        Method stream = findMethod(Collection.class, "stream", m -> true);
+        assertTrue(ReflectionUtils.getDefaultMethods(List.class).contains(stream));
     }
 }

--- a/test-java8/src/test/java/org/easymock/java8/Java8Test.java
+++ b/test-java8/src/test/java/org/easymock/java8/Java8Test.java
@@ -52,4 +52,16 @@ public class Java8Test {
         assertEquals(10, mock.normalInterfaceMethod());
         verify(mock);
     }
+
+    @Test
+    public void partialMockOnInterface() {
+        IMethods mock = partialMockBuilder(IMethods.class)
+            .addMockedMethod("defaultInterfaceMethod")
+            .createMock();
+        expect(mock.defaultInterfaceMethod()).andReturn(10);
+        replay(mock);
+        assertEquals(10, mock.defaultInterfaceMethod());
+        verify(mock);
+    }
+
 }


### PR DESCRIPTION
They're equivalent to abstract classes with concrete methods so I don't see why it is still prohibited. Now we have to convert such interfaces into abstract classes which is inconvenient. Usage example: [JDBI's SQL objects](http://jdbi.org/#_sql_objects).