### PR TITLE
Fix core source-jar, added maven-source-plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -133,6 +133,17 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Hi, I noticed that the file `easymock-4.3-sources.jar` does not contain the sources for easymock itself. This merge request fixes this.